### PR TITLE
Work on the analog sensors

### DIFF
--- a/AVR/Movement/X2/X2-Movable.h
+++ b/AVR/Movement/X2/X2-Movable.h
@@ -15,7 +15,7 @@
 #include "X2-Actuator.h"
 
 #define SANE_RSPEED_MAX 250
-#define SANE_MSPEED_MAX 400
+#define SANE_MSPEED_MAX 500
 
 namespace X2 {
 

--- a/AVR/Movement/X2/X2-Movable.h
+++ b/AVR/Movement/X2/X2-Movable.h
@@ -14,8 +14,8 @@
 
 #include "X2-Actuator.h"
 
-#define SANE_RSPEED_MAX 360
-#define SANE_MSPEED_MAX 500
+#define SANE_RSPEED_MAX 250
+#define SANE_MSPEED_MAX 400
 
 namespace X2 {
 

--- a/AVR/Sensors/LineFollow/LF3Sens.cpp
+++ b/AVR/Sensors/LineFollow/LF3Sens.cpp
@@ -9,8 +9,9 @@
 
 namespace LF {
 
-Sens3::Sens3(volatile uint8_t *PINx, uint8_t pins) : PINx(PINx), pins(pins) {
-	*(PINx + 2) |= (0b111 << pins);
+Sens3::Sens3(volatile uint8_t *PORTx, uint8_t pins) : PINx(PORTx -2), pins(pins) {
+	// Initialise the Pull-Ups
+	*(PORTx) |= (0b111 << pins);
 }
 
 //Decide on the next status of the outputs

--- a/AVR/Sensors/LineFollow/LFA2Sens.cpp
+++ b/AVR/Sensors/LineFollow/LFA2Sens.cpp
@@ -3,16 +3,16 @@
 
 namespace LF {
 
-	LFA2Sens::LFA2Sens(uint8_t const pin) : pin(pin) {
+	ASens2::ASens2(uint8_t const pin) : pin(pin) {
 	}
 
-	void LFA2Sens::update() {
+	void ASens2::update() {
 		ADC_Lib::start_measurement(pin);
 		ADC_Lib::start_measurement(pin +1);
 		updating = 2;
 	}
 
-	void LFA2Sens::ADCUpdate() {
+	void ASens2::ADCUpdate() {
 		if(ADC_Lib::measuredPin == pin) {
 			updating--;
 			readings[0] = ADC_Lib::lastResult;
@@ -26,7 +26,7 @@ namespace LF {
 			uint16_t totalReading = readings[0] + readings[1];
 			if(totalReading >= READING_THRESHOLD) {
 				this->lineStatus = OK;
-				this->lineOffset = (uint8_t)(((uint32_t)(readings[0] - readings[1]) * 127) / totalReading);
+				this->lineOffset = (int8_t)((((int32_t)readings[0] - readings[1]) * 127) / totalReading);
 			}
 			else {
 				this->lineStatus = LOST;
@@ -34,7 +34,7 @@ namespace LF {
 		}
 	}
 
-	bool LFA2Sens::isUpdated() {
+	bool ASens2::isUpdated() {
 		return this->updating == 0;
 	}
 }

--- a/AVR/Sensors/LineFollow/LFA2Sens.cpp
+++ b/AVR/Sensors/LineFollow/LFA2Sens.cpp
@@ -1,0 +1,40 @@
+
+#include "LFA2Sens.h"
+
+namespace LF {
+
+	LFA2Sens::LFA2Sens(uint8_t const pin) : pin(pin) {
+	}
+
+	void LFA2Sens::update() {
+		ADC_Lib::start_measurement(pin);
+		ADC_Lib::start_measurement(pin +1);
+		updating = 2;
+	}
+
+	void LFA2Sens::ADCUpdate() {
+		if(ADC_Lib::measuredPin == pin) {
+			updating--;
+			readings[0] = ADC_Lib::lastResult;
+		}
+		else if(ADC_Lib::measuredPin == pin+1) {
+			updating--;
+			readings[1] = ADC_Lib::lastResult;
+		}
+
+		if(updating == 0) {
+			uint16_t totalReading = readings[0] + readings[1];
+			if(totalReading >= READING_THRESHOLD) {
+				this->lineStatus = OK;
+				this->lineOffset = (uint8_t)(((uint32_t)(readings[0] - readings[1]) * 127) / totalReading);
+			}
+			else {
+				this->lineStatus = LOST;
+			}
+		}
+	}
+
+	bool LFA2Sens::isUpdated() {
+		return this->updating == 0;
+	}
+}

--- a/AVR/Sensors/LineFollow/LFA2Sens.cpp
+++ b/AVR/Sensors/LineFollow/LFA2Sens.cpp
@@ -3,33 +3,51 @@
 
 namespace LF {
 
-	ASens2::ASens2(uint8_t const pin) : pin(pin) {
+	ASens2::ASens2(uint8_t const pin) : pin(pin), sigBuffer(0) {
 	}
 
 	void ASens2::update() {
-		ADC_Lib::start_measurement(pin);
-		ADC_Lib::start_measurement(pin +1);
+		ADC_Lib::start_measurement(pin + 1);
+		ADC_Lib::start_measurement(pin + 2);
 		updating = 2;
 	}
 
 	void ASens2::ADCUpdate() {
-		if(ADC_Lib::measuredPin == pin) {
+		if(ADC_Lib::measuredPin == pin+1) {
 			updating--;
 			readings[0] = ADC_Lib::lastResult;
 		}
-		else if(ADC_Lib::measuredPin == pin+1) {
+		else if(ADC_Lib::measuredPin == pin+2) {
 			updating--;
 			readings[1] = ADC_Lib::lastResult;
 		}
 
+
 		if(updating == 0) {
 			uint16_t totalReading = readings[0] + readings[1];
-			if(totalReading >= READING_THRESHOLD) {
-				this->lineStatus = OK;
+			this->lineStatus = OK;
+
+			if(sigBuffer < 0)
+				sigBuffer++;
+			else if(sigBuffer > 0)
+				sigBuffer--;
+
+			if((PINA & 1<<pin) != 0)
+				this->sigBuffer = INTSEC_BUFFER_TICKS;
+			else if((PINA & 1 << (pin+3)) != 0)
+				this->sigBuffer = -INTSEC_BUFFER_TICKS;
+
+			if((PINA & (0b1001 << pin)) == (0b1001 << pin))
+				this->lineStatus = INTSEC;
+			else if(totalReading >= READING_THRESHOLD)
 				this->lineOffset = (int8_t)((((int32_t)readings[0] - readings[1]) * 127) / totalReading);
-			}
 			else {
 				this->lineStatus = LOST;
+
+				if(sigBuffer < 0)
+					this->lineOffset = -127;
+				else if(sigBuffer > 0)
+					this->lineOffset = 127;
 			}
 		}
 	}

--- a/AVR/Sensors/LineFollow/LFA2Sens.h
+++ b/AVR/Sensors/LineFollow/LFA2Sens.h
@@ -7,10 +7,14 @@
 
 #define READING_THRESHOLD 480
 
+#define INTSEC_BUFFER_TICKS 20
+
 namespace LF {
 
 	class ASens2 : public Basic {
 	private:
+		int8_t sigBuffer;
+
 		uint8_t const pin;
 		uint16_t readings[2] = {0, 0};
 

--- a/AVR/Sensors/LineFollow/LFA2Sens.h
+++ b/AVR/Sensors/LineFollow/LFA2Sens.h
@@ -9,7 +9,7 @@
 
 namespace LF {
 
-	class LFA2Sens : Basic {
+	class ASens2 : public Basic {
 	private:
 		uint8_t const pin;
 		uint16_t readings[2] = {0, 0};
@@ -17,7 +17,7 @@ namespace LF {
 		volatile uint8_t updating = 0;
 
 	public:
-		LFA2Sens(uint8_t const pin);
+		ASens2(uint8_t const pin);
 
 		void update();
 		void ADCUpdate();

--- a/AVR/Sensors/LineFollow/LFA2Sens.h
+++ b/AVR/Sensors/LineFollow/LFA2Sens.h
@@ -1,0 +1,29 @@
+
+#ifndef LF2_A_SENS_H
+#define LF2_A_SENS_H
+
+#include "LFBasic.h"
+#include "../../ADC/ADC_Lib.h"
+
+#define READING_THRESHOLD 480
+
+namespace LF {
+
+	class LFA2Sens : Basic {
+	private:
+		uint8_t const pin;
+		uint16_t readings[2] = {0, 0};
+
+		volatile uint8_t updating = 0;
+
+	public:
+		LFA2Sens(uint8_t const pin);
+
+		void update();
+		void ADCUpdate();
+
+		bool isUpdated();
+	};
+}
+
+#endif

--- a/AVR/Sensors/LineFollow/LFBasic.h
+++ b/AVR/Sensors/LineFollow/LFBasic.h
@@ -11,7 +11,7 @@
 #include <avr/io.h>
 
 
-// LF_OK 		//The line is under the sensors and tracked
+//LF_OK 		//The line is under the sensors and tracked
 //LF_AMBIG 	//The line is currently in an ambiguous state, no clear decision can be made
 //LF_LOST 	//No sensors have the line and it could be lost
 //LF_INTSEC	//A intersection has been found!


### PR DESCRIPTION
This PR adds the long-wanted analog sensor class, together with intersection-detection support & almost perfect 90° edge detecting.

The two center sensors for the analog sensors ought to be placed both *INSIDE* the line, and should read *higher* voltage the *darker* the line.
The two outer sensors should be placed as distant from the center line as possible, to allow for a very wide detecting range in case of a missed line, as well as as little as possible false readings of 90° line sections.
They can be digital, but must be connected to the analog PORTA (as for now, at least).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xasworks/xascode/13)
<!-- Reviewable:end -->
