### PR TITLE
MQTT persistence upgrade!

### DIFF
--- a/Ruby/MQTT/lib/mqtt/persistence.rb
+++ b/Ruby/MQTT/lib/mqtt/persistence.rb
@@ -101,7 +101,7 @@ module MQTT
 
 			if(callback)
 				@paramList[key][:cbList] << callback
-				yield(@paramList[key][:current], nil);
+				yield(@paramList[key][:current], nil) if @paramList[key][:current]
 			end
 
 			return @paramList[key][:current];

--- a/Ruby/MQTT/lib/mqtt/persistence.rb
+++ b/Ruby/MQTT/lib/mqtt/persistence.rb
@@ -1,0 +1,127 @@
+
+require 'json'
+
+module MQTT
+	class Persistence
+
+
+		def initialize(mqtt, dir = "Persistence")
+			raise ArgumentError, "Not a mqtt class!" unless mqtt.is_a? MQTT::SubHandler
+
+			@mqtt = mqtt;
+			@dir  = dir;
+
+			@paramList = Hash.new();
+		end
+
+		def _prepare_send(data, key)
+			case @paramList[key][:type]
+			when Time
+				return nil.to_json unless data;
+				return data.to_i.to_json;
+			else
+				return data.to_json
+			end
+		end
+		def _parse_received(data, key)
+			begin
+				case @paramList[key][:type]
+				when Time
+					i = JSON.parse(data);
+					return nil unless i.is_a? Numeric;
+					return Time.at(i);
+				else
+					return JSON.parse(data);
+				end
+			rescue JSON::ParserError
+				return nil;
+			end
+		end
+
+		def _process_data(data, key)
+			return unless param = @paramList[key];
+			return if param[:current_raw] == data;
+
+			oldData = param[:current];
+			param[:current] = _parse_received(data, key);
+			param[:cbList].each do |cb|
+				cb.call(param[:current], oldData);
+			end
+
+			if(param[:first])
+				param.delete :first
+				param.cbList = [param[:cbList], param[:change_cb]].flatten;
+			end
+		end
+
+		def setup!(key, type_class = nil)
+			raise ArgumentError, "Key needs to be a symbol!" unless key.is_a? Symbol
+
+			@paramList[key] = {
+				type: 	type_class,
+				current_raw: nil,
+				current: nil,
+				cbList:	Array.new(),
+
+				first:		true,
+				change_cb:	Array.new(),
+			}
+		end
+		def setup(key, type_class = nil)
+			return if @paramList.key? key;
+			setup!(key, type_class);
+		end
+
+		def start()
+			@mqtt.subscribe_to "#{@dir}/+" do |data, key|
+				_process_data(data, key[0].to_sym);
+			end
+		end
+
+		def [](key, &callback)
+			raise ArgumentError, "Key needs to be a symbol!" unless key.is_a? Symbol
+			raise ArgumentError, "Key has not been set up!" unless @paramList.key? key;
+
+			if(callback)
+				@paramList[key][:cbList] << callback
+				callback.call(@paramList[:current], nil);
+			end
+
+			return @paramList[key][:current];
+		end
+		def []=(key, data)
+			raise ArgumentError, "Key needs to be a symbol!" unless key.is_a? Symbol
+			raise ArgumentError, "Key has not been set up!" unless param = @paramList[key];
+
+			newString = _prepare_send(data, key);
+			return if param[:current_raw] == newString;
+
+			if(param[:first])
+				param.delete :first
+				param[:cbList] = [param[:cbList], param[:change_cb]].flatten;
+			end
+
+			oldData = param[:current];
+			param[:current] = data;
+			param.cbList.each do |cb|
+				cb.call(param[:current], oldData);
+			end
+			param[:current_raw] = newString;
+
+			@mqtt.publish_to "#{dir}/#{key}", newString, retain: true;
+		end
+
+		def on_change(key, &callback)
+			raise ArgumentError, "Key needs to be a symbol!" unless key.is_a? Symbol
+			raise ArgumentError, "Key has not been set up!" unless @paramList.key? key;
+
+			raise ArgumentError, "A callback needs to be given!" unless callback;
+
+			if(@paramList[key][:first])
+				@paramList[key][:change_cb] << callback;
+			else
+				@paramList[key][:cbList] << callback;
+			end
+		end
+	end
+end

--- a/Ruby/MQTT/lib/mqtt/persistence.rb
+++ b/Ruby/MQTT/lib/mqtt/persistence.rb
@@ -96,7 +96,7 @@ module MQTT
 
 			if(callback)
 				@paramList[key][:cbList] << callback
-				callback.call(@paramList[:current], nil);
+				yield(@paramList[key][:current], nil);
 			end
 
 			return @paramList[key][:current];

--- a/Ruby/MQTT/lib/mqtt/persistence.rb
+++ b/Ruby/MQTT/lib/mqtt/persistence.rb
@@ -4,6 +4,16 @@ require_relative 'persistence_extensions.rb'
 
 module MQTT
 	class Persistence
+		# Provide persistence for tasks that regularly restart, using MQTT retained messages.
+		# As a fun side effect, this also allows for live monitoring and modifying!
+		#
+		# @author Xasin
+
+
+		# Initialize the Persistence instance.
+		#  This will immediately connect and subscribe to the wildcard of `dir + "/#"`
+		# @param mqtt [MQTT::SubHandler] The MQTT instance to use for storing/communication
+		# @param dir [String] A valid MQTT topic string under which to nest the persistence.
 		def initialize(mqtt, dir = "Persistence")
 			raise ArgumentError, "Not a mqtt class!" unless mqtt.is_a? MQTT::SubHandler
 
@@ -18,6 +28,9 @@ module MQTT
 			end
 		end
 
+
+		# Prepare a piece of data to be sent to the MQTT topic
+		# It must either respond to `to_mqtt_string` or to `to_json`
 		def _prepare_send(data, key)
 			if(data.respond_to? :to_mqtt_string)
 				return data.to_mqtt_string;
@@ -25,7 +38,13 @@ module MQTT
 				return data.to_json
 			end
 		end
+		private :_prepare_send
 
+		# Parse a raw String received from MQTT.
+		# If the given class type responds to `from_mqtt_string`, that
+		# function is used for processing.
+		# `JSON.parse` will be used otherwise.
+		# @return [key-type, nil] Returns the parsed data, nil if that fails.
 		def _parse_received(data, key)
 			begin
 				dType = @paramList[key][:type];
@@ -38,7 +57,10 @@ module MQTT
 				return nil;
 			end
 		end
+		private :_parse_received
 
+		# This processes new data received from MQTT.
+		# It returns if the raw string hasn't changed, and will trigger the callbacks.
 		def _process_data(data, key)
 			return if @rawData[key] == data;
 			@rawData[key] = data;
@@ -56,7 +78,13 @@ module MQTT
 				param[:cbList] = [param[:cbList], param[:change_cb]].flatten;
 			end
 		end
+		private :_process_data
 
+		# Force setting up a key, overwriting what was already configured.
+		# You usually don't need this!
+		# @param key [Symbol] The key that should be set up.
+		# @param type_class [#from_mqtt_string] The class to use to parse the data. A JSON-conversion
+		#  is used if the class doesn't respond to `from_mqtt_string`
 		def setup!(key, type_class = nil)
 			raise ArgumentError, "Key needs to be a symbol!" unless key.is_a? Symbol
 
@@ -74,11 +102,19 @@ module MQTT
 				_process_data(data, key);
 			end
 		end
+		# Set up a key, unless it has already been configured.
+		# @param (See #setup!)
 		def setup(key, type_class = nil)
 			return if @paramList.key? key;
 			setup!(key, type_class);
 		end
 
+		# Read out a given, set-up key, returning `nil` if nothing has been read yet (or the value is nil right now),
+		# returning the data otherwise.
+		# If a block is given (using the on_set alias), this block will be added as a callback.
+		# @param key [Symbol] The key to fetch. Must have been set up first!
+		# @yieldparam newData The newly parsed data (depending on the key's type.)
+		# @yieldparam oldData The former data that was present.
 		def [](key, &callback)
 			raise ArgumentError, "Key needs to be a symbol!" unless key.is_a? Symbol
 			raise ArgumentError, "Key has not been set up!" unless @paramList.key? key;
@@ -92,6 +128,10 @@ module MQTT
 		end
 		alias on_set []
 
+		# Set a given key to a new value, provided the key has been set up.
+		# Will run the `on_change` and `on_set` callbacks immediately, then publish to MQTT.
+		# @param key [Symbol] The key to write. Must have been set up first!
+		# @param data [#to_json, #to_mqtt_string] The data to write.
 		def []=(key, data)
 			raise ArgumentError, "Key needs to be a symbol!" unless key.is_a? Symbol
 			raise ArgumentError, "Key has not been set up!" unless param = @paramList[key];
@@ -114,6 +154,11 @@ module MQTT
 			@mqtt.publish_to "#{@dir}/#{key}", newString, retain: true;
 		end
 
+		# Add a callback to be triggered whenever the key's value changes.
+		# The slight difference to `on_set` is that this callback is not executed on the very first
+		# value received from MQTT, making it easier to not trigger some code on restart, only on actual changes.
+		# @param (See #[])
+		# @yieldparam (See #[])
 		def on_change(key, &callback)
 			raise ArgumentError, "Key needs to be a symbol!" unless key.is_a? Symbol
 			raise ArgumentError, "Key has not been set up!" unless @paramList.key? key;

--- a/Ruby/MQTT/lib/mqtt/persistence.rb
+++ b/Ruby/MQTT/lib/mqtt/persistence.rb
@@ -22,23 +22,28 @@ module MQTT
 				return data.to_mqtt_string;
 			end
 
-			case @paramList[key][:type]
-			when Time
+			dType = @paramList[key][:type]
+			if(dType == Time)
 				return nil.to_json unless data;
 				return data.to_i.to_json;
 			else
 				return data.to_json
 			end
 		end
+
 		def _parse_received(data, key)
 			begin
+				if((cData = @paramList[key][:current]).respond_to? :update_from_mqtt)
+					cData.update_from_mqtt(data);
+					return cData;
+				end
+
 				dType = @paramList[key][:type];
 				if(dType.respond_to? :from_mqtt_string)
 					return dType.from_mqtt_string(data);
 				end
 
-				case @paramList[key][:type]
-				when Time
+				if(dType == Time)
 					i = JSON.parse(data);
 					return nil unless i.is_a? Numeric;
 					return Time.at(i);

--- a/Ruby/MQTT/lib/mqtt/persistence.rb
+++ b/Ruby/MQTT/lib/mqtt/persistence.rb
@@ -1,5 +1,6 @@
 
 require 'json'
+require_relative 'persistence_extensions.rb'
 
 module MQTT
 	class Persistence
@@ -20,12 +21,6 @@ module MQTT
 		def _prepare_send(data, key)
 			if(data.respond_to? :to_mqtt_string)
 				return data.to_mqtt_string;
-			end
-
-			dType = @paramList[key][:type]
-			if(dType == Time)
-				return nil.to_json unless data;
-				return data.to_i.to_json;
 			else
 				return data.to_json
 			end
@@ -33,20 +28,9 @@ module MQTT
 
 		def _parse_received(data, key)
 			begin
-				if((cData = @paramList[key][:current]).respond_to? :update_from_mqtt)
-					cData.update_from_mqtt(data);
-					return cData;
-				end
-
 				dType = @paramList[key][:type];
 				if(dType.respond_to? :from_mqtt_string)
 					return dType.from_mqtt_string(data);
-				end
-
-				if(dType == Time)
-					i = JSON.parse(data);
-					return nil unless i.is_a? Numeric;
-					return Time.at(i);
 				else
 					return JSON.parse(data, symbolize_names: true);
 				end

--- a/Ruby/MQTT/lib/mqtt/persistence_extensions.rb
+++ b/Ruby/MQTT/lib/mqtt/persistence_extensions.rb
@@ -1,0 +1,13 @@
+
+class Time
+	def to_mqtt_string
+		to_f().to_json()
+	end
+
+	def self.from_mqtt_string(string)
+		data = JSON.parse(string);
+		return nil unless data.is_a? Numeric;
+
+		return self.at(data);
+	end
+end

--- a/Ruby/MQTT/tests/tc_persistence.rb
+++ b/Ruby/MQTT/tests/tc_persistence.rb
@@ -90,4 +90,8 @@ class TestPersistence < Minitest::Test
 		assert_equal testHash, @setOldData;
 		assert_equal testHash, @changeOldData;
 	end
+
+	def test_conversion
+
+	end
 end

--- a/Ruby/MQTT/tests/tc_persistence.rb
+++ b/Ruby/MQTT/tests/tc_persistence.rb
@@ -92,6 +92,13 @@ class TestPersistence < Minitest::Test
 	end
 
 	def test_conversion
+		testTime = Time.at(rand(0..99999999));
 
+		@persistence.setup(:test_a, Time);
+		@persistence[:test_a] = testTime;
+
+		@mqtt.process_all();
+
+		assert_equal testTime.to_i, @mqtt.retained_topics["Persistence/test_a"];
 	end
 end

--- a/Ruby/MQTT/tests/tc_persistence.rb
+++ b/Ruby/MQTT/tests/tc_persistence.rb
@@ -1,0 +1,68 @@
+
+require 'minitest/autorun'
+
+require_relative '../lib/mqtt/sub_testing.rb'
+require_relative '../lib/mqtt/persistence.rb'
+
+class TestPersistence < Minitest::Test
+	def setup()
+		@mqtt = MQTT::Testing::SubHandler.new(test_handler: self);
+		@persistence = MQTT::Persistence.new(@mqtt);
+	end
+	def teardown()
+		@mqtt.full_reset();
+	end
+
+	def test_pub_receive()
+		@persistence.setup(:test_a);
+
+		testHash = {"Test" => "Hash"};
+
+		@persistence[:test_a] = testHash;
+		@mqtt.process_all
+
+		assert_equal testHash.to_json, @mqtt.retained_topics["Persistence/test_a"];
+
+		testHash = {
+			test: "Data",
+			nr:   2,
+		}
+
+		@mqtt.publish_to "Persistence/test_a", testHash.to_json;
+		@mqtt.process_all
+
+		assert_equal testHash, @persistence[:test_a]
+	end
+
+	def test_retained_receive
+		testHash = {test: "Data"}
+		@mqtt.publish_to "Persistence/test_a", testHash.to_json, retain: true;
+		@mqtt.process_all
+
+		@persistence.setup(:test_a);
+
+		assert_equal testHash, @persistence[:test_a]
+	end
+
+	def test_callbacks
+		testHash = {test: "Data"}
+		@mqtt.publish_to "Persistence/test_a", testHash.to_json, retain: true;
+
+		assert_raises do
+			@persistence.on_set(:test_a) do end
+		end
+
+		@persistence.setup(:test_a)
+		@persistence.on_set(:test_a) do |newData, oldData|
+			@setNewData = newData,
+			@setOldData = oldData;
+		end
+		@persistence.on_change(:test_a) do |newData, oldData|
+			@changeNewData = newData;
+			@changeOldData = oldData;
+		end
+
+		assert_equal testHash, @setNewData;
+		[@setOldData, @changeNewData, @changeOldData].each do |d| assert_nil d; end
+	end
+end


### PR DESCRIPTION
A lovely, if not slightly silly way of storing data between restarts will be introduced: 
The MQTT persistence gem!

It handles most tasks of setting and getting data from the MQTT server, all to allow you to store it, using MQTT's own retained messages and restart-persistence to properly reload everything!
It features:

- Differentiation between the initial load and later publishes/receives
- Automatic conversion of data (mostly from/to JSON)
  - Custom conversation possible!
- Change-tracking to also utilize this for live reconfiguration and monitoring!

This'll also close #24!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xasworks/xascode/28)
<!-- Reviewable:end -->
